### PR TITLE
fix: rename 'coverImage' to 'cover_image' and show on index

### DIFF
--- a/src/components/PostCard.vue
+++ b/src/components/PostCard.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="post-card content-box" :class="{'post-card--has-poster' : post.poster}">
     <div class="post-card__header">
-      <g-image alt="Cover image" v-if="post.coverImage" class="post-card__image" :src="post.coverImage" />
+      <g-image alt="Cover image" v-if="post.cover_image" class="post-card__image" :src="post.cover_image" />
     </div>
     <div class="post-card__content">
       <h2 class="post-card__title" v-html="post.title" />
       <p class="post-card__description" v-html="post.description" />
-      
+
       <PostMeta class="post-card__meta" :post="post" />
       <PostTags class="post-card__tags" :post="post" />
 

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -21,6 +21,7 @@ query {
         date (format: "D. MMMM YYYY")
         timeToRead
         description
+        cover_image (width: 770, height: 380, blur: 10)
         path
         tags {
           id

--- a/src/templates/Post.vue
+++ b/src/templates/Post.vue
@@ -11,7 +11,7 @@
 
     <div class="post content-box">
       <div class="post__header">
-        <g-image alt="Cover image" v-if="$page.post.coverImage" :src="$page.post.coverImage" />
+        <g-image alt="Cover image" v-if="$page.post.cover_image" :src="$page.post.cover_image" />
       </div>
 
       <div class="post__content" v-html="$page.post.content" />


### PR DESCRIPTION
In [hjvedvik's](https://github.com/hjvedvik) [last commit](https://github.com/gridsome/gridsome-starter-blog/commit/3140e47b21a306ec89b11b77698e3e734d132168) coverImage was renamed to cover_image but not at all places. This PR fixes this, so that cover images are shown again