### PR TITLE
Fix style for multi-line code

### DIFF
--- a/src/assets/style/_code.scss
+++ b/src/assets/style/_code.scss
@@ -16,10 +16,7 @@ pre {
 }
 
 code {
-  background-color: var(--bg-code);
-  border: 1px solid var(--border-color);
   font-size: .85em;
-  padding: .2em .5em;
 }
 
 code[class*="language-"],
@@ -57,7 +54,10 @@ pre[class*="language-"] {
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
+	background-color: var(--bg-code);
+	border: 1px solid var(--border-color);
 	border-radius: var(--radius);
+	padding: .2em .5em;
 	white-space: normal;
 }
 
@@ -101,7 +101,6 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string {
 	color: #9a6e3a;
-	background: hsla(0, 0%, 100%, .5);
 }
 
 .token.atrule,


### PR DESCRIPTION
There is a style issue for the code section. It has styles that should only be applied to the inline code.

Before (dark mode)
![localhost_8081_what-s-new-in-e-s2019_](https://user-images.githubusercontent.com/2037792/68983404-995ced80-07e9-11ea-9ad0-3140f9312838.png)
After (dark mode)
![localhost_8081_what-s-new-in-e-s2019_ (1)](https://user-images.githubusercontent.com/2037792/68983437-b0034480-07e9-11ea-9a76-efc83351867f.png)

Before
![localhost_8081_what-s-new-in-e-s2019_ (2)](https://user-images.githubusercontent.com/2037792/68983424-a7ab0980-07e9-11ea-8e2a-bb74576d2017.png)
After
![localhost_8081_](https://user-images.githubusercontent.com/2037792/68983439-b1cd0800-07e9-11ea-8538-f36b1f45d108.png)

With these changes, inline code won't change the style.
