### PR TITLE
Removing need for important css property on post-tags__link class

### DIFF
--- a/src/assets/style/_base.scss
+++ b/src/assets/style/_base.scss
@@ -15,7 +15,7 @@ body {
   line-height: 1.5;
 }
 
-a:not(.button) {
+a:not(.button):not(.post-tags__link) {
 	color: var(--link-color);
  	transition: opacity .2s;
 	&:hover {

--- a/src/components/PostTags.vue
+++ b/src/components/PostTags.vue
@@ -19,10 +19,9 @@ export default {
   &__link {
   	margin-right: .7em;
   	font-size: .8em;
-  	color: currentColor;
   	text-decoration: none;
   	background-color: var(--bg-color);
-  	color: currentColor!important; //Todo: remove important;
+  	color: currentColor;
   	padding: .5em;
   	border-radius: var(--radius);
   }


### PR DESCRIPTION
I found a way to fix the need for the "!important" tag in the style sheets using cascading :not() selectors.