### PR TITLE
Add new styling to code blocks

### DIFF
--- a/src/templates/Post.vue
+++ b/src/templates/Post.vue
@@ -79,6 +79,13 @@ query Post ($id: ID!) {
   text-align: center;
 }
 
+pre {
+  code {
+    background-color: transparent;
+    border: none;
+  }
+}
+
 .post {
 
   &__header {


### PR DESCRIPTION
I am proposing editing the styles for the default Prism code blocks. In the screenshot below, you can see the default stylings create a "bar" around each link with in a code block. I have added styles in the `Post.vue` file to override this condition without touching the default Prismjs stylesheet:

```css
pre {
    code {
      background-color: transparent;
      border: none;
    }
  }
```

![Screenshot from 2020-07-20 08-19-30](https://user-images.githubusercontent.com/13651291/87937800-6303fc00-ca63-11ea-8446-9a89568b48f8.png)
